### PR TITLE
Added the possibility to toggle notification only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ The alert is visually and acoustically an exact copy of the famous addOn *_NPCSc
 There are two commands:<br/>
 **/unitscan** lists the active scan targets<br/>
 **/unitscan name** adds/removes **name** to/from the scan targets<br/>
+**/unitscanonce** toggle unitscan to notify only once per reload per target.
 When a target is detected it is removed and has to be readded to continue scanning for it.

--- a/unitscan.lua
+++ b/unitscan.lua
@@ -21,6 +21,7 @@ local YELLOW = {1, 1, .15}
 local CHECK_INTERVAL = .1
 
 unitscan_targets = {}
+unitscan_notify_once = false
 local found = {}
 
 do
@@ -50,7 +51,9 @@ function unitscan.target(name)
 			unitscan.discovered_unit = name
 		end
 	else
-		found[name] = false
+		if not unitscan_notify_once then
+			found[name] = false
+		end
 	end
 end
 
@@ -299,11 +302,13 @@ function unitscan.toggle_target(name)
 		unitscan.print('- ' .. key)
 	elseif key ~= '' then
 		unitscan_targets[key] = true
+		found[key] = false
 		unitscan.print('+ ' .. key)
 	end
 end
 	
 SLASH_UNITSCAN1 = '/unitscan'
+SLASH_UNITSCAN1 = '/us'
 function SlashCmdList.UNITSCAN(parameter)
 	local _, _, name = strfind(parameter, '^%s*(.-)%s*$')
 	
@@ -313,5 +318,17 @@ function SlashCmdList.UNITSCAN(parameter)
 		end
 	else
 		unitscan.toggle_target(name)
+	end
+end
+
+SLASH_USO1 = '/uso'
+SLASH_USO2 = '/unitscanonce'
+function SlashCmdList.USO(parameter)
+	unitscan_notify_once = not unitscan_notify_once
+
+	if (unitscan_notify_once == true) then
+		unitscan.print('Unitscan will now notify only once per reload per target.')
+	else
+		unitscan.print('Unitscan will now always notify when the target is range.')
 	end
 end


### PR DESCRIPTION
This should allow to toggle being notified only once per reload per target as, when enabled, it prevents unitscan to send another notification.

(Only did classic era as it's the only one I play)